### PR TITLE
Allows unicode values greater than 0xFFFF

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -12,7 +12,7 @@ export function mapCss(data: string, debug?: boolean) {
             if (!value) {
                 continue;
             }
-            const realVal = String.fromCharCode(parseInt(value, 16));
+            const realVal = String.fromCodePoint(parseInt(value, 16));
             for (let key of keys) {
                 key = key
                     .trim() // remove spaces


### PR DESCRIPTION
This pull request replaces String.fromCharCode with String.fromCodePoint because the latter does not work with unicode characters that are greater than 0xFFFF.

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCodePoint#compared_to_fromcharcode for the differences between the functions.

The purpose of this is to support font packages like [@mdi/font](https://github.com/Templarian/MaterialDesign-Webfont) which, as of version 5, uses code points that are greater than 0xFFFF.